### PR TITLE
Build support for 0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && \
 
 WORKDIR /tmp
 
-
 # Download and install newer, Elm 0.16-compatible Haskell Platform
 RUN wget "https://haskell.org/platform/download/7.10.3/haskell-platform-7.10.3-unknown-posix-x86_64.tar.gz"
 RUN tar xfz "./haskell-platform-7.10.3-unknown-posix-x86_64.tar.gz"
@@ -28,7 +27,7 @@ ENV LANG en_US.utf8
 
 # Install Elm
 ENV ELM_VERSION 0.16
-WORKDIR /tmp  
+
 RUN curl https://raw.githubusercontent.com/elm-lang/elm-platform/master/installers/BuildFromSource.hs > BuildFromSource.hs
 RUN runhaskell BuildFromSource.hs ${ELM_VERSION}
 RUN cp Elm-Platform/${ELM_VERSION}/.cabal-sandbox/bin/* /app/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,25 @@ ENV PATH /root/.cabal/bin:$PATH
 RUN apt-get update && \
     apt-get -y install haskell-platform wget libncurses5-dev && \
     apt-get clean
+
+WORKDIR /tmp
+
+RUN wget "https://haskell.org/platform/download/7.10.3/haskell-platform-7.10.3-unknown-posix-x86_64.tar.gz"
+RUN tar xfz "./haskell-platform-7.10.3-unknown-posix-x86_64.tar.gz"
+RUN "./install-haskell-platform.sh"
+
 RUN cabal update && ${CABAL_INSTALL} cabal-install
 
 RUN mkdir -p /app/bin
 ENV PATH /app/bin:$PATH
+ENV LANG en_US.utf8
 
 # Install Elm
-ENV ELM_VERSION 0.15.1
-RUN cd /tmp \
-  && curl https://raw.githubusercontent.com/elm-lang/elm-platform/master/installers/BuildFromSource.hs > BuildFromSource.hs \
-  && runhaskell BuildFromSource.hs ${ELM_VERSION} \
-  && cp Elm-Platform/${ELM_VERSION}/bin/* /app/bin/
+ENV ELM_VERSION 0.16
+WORKDIR /tmp  
+RUN curl https://raw.githubusercontent.com/elm-lang/elm-platform/master/installers/BuildFromSource.hs > BuildFromSource.hs
+RUN runhaskell BuildFromSource.hs ${ELM_VERSION}
+RUN cp Elm-Platform/${ELM_VERSION}/.cabal-sandbox/bin/* /app/bin/
 
 # Startup scripts for heroku
 RUN mkdir -p /app/.profile.d /app/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
 
 WORKDIR /tmp
 
+
+# Download and install newer, Elm 0.16-compatible Haskell Platform
 RUN wget "https://haskell.org/platform/download/7.10.3/haskell-platform-7.10.3-unknown-posix-x86_64.tar.gz"
 RUN tar xfz "./haskell-platform-7.10.3-unknown-posix-x86_64.tar.gz"
 RUN "./install-haskell-platform.sh"
@@ -21,6 +23,7 @@ RUN cabal update && ${CABAL_INSTALL} cabal-install
 
 RUN mkdir -p /app/bin
 ENV PATH /app/bin:$PATH
+# Required for Elm to compile properly
 ENV LANG en_US.utf8
 
 # Install Elm


### PR DESCRIPTION
[As I discovered on OSX](https://github.com/elm-lang/elm-platform/issues/120), version 0.16 of Elm requires a pretty new build toolchain – newer than what Ubuntu currently provides.

This Dockerfile installs the correct Haskell platform so that the build can succeed.

NB: I left the original "haskell-platform" package in the first `apt-get install` so that:
1. the Docker cache wouldn't bust
2. necessary packages would be present for the subsequent haskell platform install.

Also worth noting, the `0.16` build of Elm puts the bin directory inside a cabal sandbox, so the cp command has changed too.

Fixes #9.
