### PR TITLE
Make Elm available for other buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,6 +42,7 @@ mkcd()
     mkdir -p $1 && cd $1
 }
 
+echo "export PATH=${cache}/bin/elm-${ELM_VERSION}:$PATH" >> $buildpack/export
 PATH=${cache}/bin/elm-${ELM_VERSION}:$PATH
 
 mkcd ${cache}/bin/elm-${ELM_VERSION}


### PR DESCRIPTION
> An app can be composed by multiple buildpacks which run in sequence. In order to provide an environment for subsequent buildpacks, a buildpack can create a $buildpack_dir/export script to be executed when the following buildpack is run.

[Reference.](https://devcenter.heroku.com/articles/buildpack-api#composing-multiple-buildpacks)

Fixes #11 
