### PR TITLE
Ability to specify custom command to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Check out the example app [elm-todomvc](https://github.com/evancz/elm-todomvc). 
 - Add an [`app.json`](https://github.com/evancz/elm-todomvc/blob/master/app.json) file
   - Ensure that a second buildpack provides the web server (elm-todomvc uses the static buildpack)
 - Specify the value of `ELM_COMPILE` (command used to compile your Elm sources) in `app.json`
+- Optionally specify the value of `ELM_PACKAGE_INSTALL` (command used to install your dependencies) in `app.json`. By default `elm package install --yes` will be used.
 - Deploy!
 
 ## Customizing

--- a/bin/compile
+++ b/bin/compile
@@ -58,17 +58,24 @@ if test -d ${cache}/elm-stuff; then
    cp -r ${cache}/elm-stuff ${build}/elm-stuff
 fi
 
-cd ${build}
-echo "-----> Fetching dependencies"
-elm package install --yes | indent
-
 get_app_json_env() {
     name=$1
     if ! test -f ${build}/app.json; then
         error "app.json missing."
     fi
-    python -c "import json; j=json.load(open('app.json')); print j['env']['${name}']"
+    python -c "import json; j=json.load(open('app.json')); print j['env'].get('${name}')"
 }
+
+cd ${build}
+ELM_PACKAGE_INSTALL=$(get_app_json_env "ELM_PACKAGE_INSTALL")
+
+if [ "$ELM_PACKAGE_INSTALL" == "None" ]; then
+  echo "-----> Fetching dependencies"
+  elm package install --yes | indent
+else
+  echo "-----> Fetching dependencies with ${ELM_PACKAGE_INSTALL}"
+  $ELM_PACKAGE_INSTALL | indent
+fi
 
 ELM_COMPILE=$(get_app_json_env "ELM_COMPILE")
 echo "-----> Compiling with ${ELM_COMPILE}"


### PR DESCRIPTION
Sometimes just running `elm package install --yes` is not enough. For [this app](https://github.com/brianstorti/jan), for example, my `Elm` code is in `web/elm`, so I'd need to install the package from there.

With this change we will be able to specify an `ELM_PACKAGE_INSTALL` in `app.json` for a custom command, and in case it's not present, it'll simply use `elm pakage-install --yes`. 
