### PR TITLE
Build elm binaries using npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Sep 20, 2016
+
+- [Build] #20: Retrieve elm binaries using npm
+
 ## Sep 19, 2016
 
 - Upgrade to Elm 0.17.1
@@ -7,7 +11,7 @@
 ## May 19, 2016
 
 - Upgrade Elm to [0.17](http://elm-lang.org/blog/farewell-to-frp)
-- #12: Make Elm available for other buildpacks 
+- #12: Make Elm available for other buildpacks
 
 ## Jan 20, 2016
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,28 +3,17 @@
 
 FROM heroku/cedar
 
-# ENV PATH /root/.cabal/bin:$PATH
+RUN apt-get -qy update && apt-get -y install npm nodejs-legacy
 ENV PATH /app/bin:$PATH
-RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu trusty main '|tee /etc/apt/sources.list.d/haskell.list
-RUN apt-get update
 WORKDIR /tmp
 
-# Install Haskell
-ENV GHC_VERSION 7.10.3
-ENV CABAL_VERSION 1.24
-RUN apt-get install -y --force-yes ghc-${GHC_VERSION}
-RUN apt-get install -y --force-yes cabal-install-${CABAL_VERSION}
-ENV PATH /opt/ghc/${GHC_VERSION}/bin:/opt/cabal/${CABAL_VERSION}/bin:$PATH
 
 # Install Elm
 ENV ELM_VERSION 0.17.1
-# Required for Elm to compile properly
-ENV LANG en_US.utf8
 
-RUN curl -LO https://raw.githubusercontent.com/elm-lang/elm-platform/master/installers/BuildFromSource.hs
-RUN runhaskell BuildFromSource.hs ${ELM_VERSION}
+RUN npm install -g elm@${ELM_VERSION}
 RUN mkdir -p /app/.profile.d /app/bin
-RUN cp Elm-Platform/${ELM_VERSION}/.cabal-sandbox/bin/* /app/bin/
+RUN cp /usr/local/lib/node_modules/elm/Elm-Platform/${ELM_VERSION}/.cabal-sandbox/bin/* /app/bin
 
 # Startup scripts for heroku
 RUN echo "export PATH=\"/app/bin:\$PATH\"" > /app/.profile.d/appbin.sh


### PR DESCRIPTION
The previous way of doing it (using BuildFromSource.hs) is not reliable as the binaries are not being generated properly.

npm install is also much faster than building from the source.

Tested the change by deploying elm-todomvc - thereby also verifying #19.
