### PR TITLE
Optionally disable the build cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ export ELM_VERSION=0.15
 
 ### Build Cache
  
-By default, this buildpack will save and reuse intermediate build objects between deploys. If you want to perform a clean build on every deploy, you say so in your .buildpack.env file:
+By default, this buildpack will save and reuse intermediate build objects between deploys. If you want to perform a clean build on every deploy, you may specify that in your .buildpack.env file:
 
 ```
 $ cat > .buildpack.env

--- a/README.md
+++ b/README.md
@@ -12,12 +12,24 @@ Check out the example app [elm-todomvc](https://github.com/srid/elm-todomvc). In
 
 ## Customizing
 
+### Elm Version
+
 The buildpack aims to use the latest version of Elm by default. To specify an alternative Elm
 version, create this file in your repo:
 
 ```
 $ cat > .buildpack.env
 export ELM_VERSION=0.15
+^D
+```
+
+### Build Cache
+ 
+By default, this buildpack will save and reuse intermediate build objects between deploys. If you want to perform a clean build on every deploy, you say so in your .buildpack.env file:
+
+```
+$ cat > .buildpack.env
+export CACHE_BUILD_OBJECTS=false
 ^D
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The buildpack aims to use the latest version of Elm by default. To specify an al
 version, create this file in your repo:
 
 ```
-$ cat > .buildpack.env
+$ cat .buildpack.env
 export ELM_VERSION=0.15
 ^D
 ```
@@ -28,7 +28,7 @@ export ELM_VERSION=0.15
 By default, this buildpack will save and reuse intermediate build objects between deploys. If you want to perform a clean build on every deploy, you may specify that in your .buildpack.env file:
 
 ```
-$ cat > .buildpack.env
+$ cat .buildpack.env
 export CACHE_BUILD_OBJECTS=false
 ^D
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -18,6 +18,7 @@ if test -f ${build}/.buildpack.env; then
 fi
 
 ELM_VERSION=${ELM_VERSION:-0.18.0}
+CACHE_BUILD_OBJECTS=${CACHE_BUILD_OBJECTS:-true}
 S3_URL=https://s3.amazonaws.com/heroku-buildpack-elm/assets
 
 download() {
@@ -54,9 +55,11 @@ download ${S3_URL}/elm/${ELM_VERSION} elm-make
 chmod -R a+x ${cache}/bin
 
 # Restore elm package cache
-if test -d ${cache}/elm-stuff; then
-   echo "-----> Restoring Elm cache"
-   cp -r ${cache}/elm-stuff ${build}/elm-stuff
+if [ $CACHE_BUILD_OBJECTS = true ]; then
+  if test -d ${cache}/elm-stuff; then
+    echo "-----> Restoring Elm cache"
+    cp -r ${cache}/elm-stuff ${build}/elm-stuff
+  fi
 fi
 
 cd ${build}
@@ -75,5 +78,7 @@ ELM_COMPILE=$(get_app_json_env "ELM_COMPILE")
 echo "-----> Compiling with ${ELM_COMPILE}"
 ${ELM_COMPILE} | indent
 
-# Copy package and compile artifacts back to cache
-cp -r ${build}/elm-stuff ${cache}/
+if [ $CACHE_BUILD_OBJECTS = true ]; then
+  # Copy package and compile artifacts back to cache
+  cp -r ${build}/elm-stuff ${cache}/
+fi

--- a/bin/compile
+++ b/bin/compile
@@ -53,12 +53,6 @@ download ${S3_URL}/elm/${ELM_VERSION} elm-make
 
 chmod -R a+x ${cache}/bin
 
-# Restore elm package cache
-if test -d ${cache}/elm-stuff; then
-   echo "-----> Restoring Elm cache"
-   cp -r ${cache}/elm-stuff ${build}/elm-stuff
-fi
-
 cd ${build}
 echo "-----> Fetching dependencies"
 elm package install --yes | indent
@@ -74,6 +68,3 @@ get_app_json_env() {
 ELM_COMPILE=$(get_app_json_env "ELM_COMPILE")
 echo "-----> Compiling with ${ELM_COMPILE}"
 ${ELM_COMPILE} | indent
-
-# Copy package and compile artifacts back to cache
-cp -r ${build}/elm-stuff ${cache}/

--- a/bin/compile
+++ b/bin/compile
@@ -53,6 +53,12 @@ download ${S3_URL}/elm/${ELM_VERSION} elm-make
 
 chmod -R a+x ${cache}/bin
 
+# Restore elm package cache
+if test -d ${cache}/elm-stuff; then
+   echo "-----> Restoring Elm cache"
+   cp -r ${cache}/elm-stuff ${build}/elm-stuff
+fi
+
 cd ${build}
 echo "-----> Fetching dependencies"
 elm package install --yes | indent
@@ -68,3 +74,6 @@ get_app_json_env() {
 ELM_COMPILE=$(get_app_json_env "ELM_COMPILE")
 echo "-----> Compiling with ${ELM_COMPILE}"
 ${ELM_COMPILE} | indent
+
+# Copy package and compile artifacts back to cache
+cp -r ${build}/elm-stuff ${cache}/

--- a/bin/compile
+++ b/bin/compile
@@ -56,10 +56,10 @@ chmod -R a+x ${cache}/bin
 
 # Restore elm package cache
 if [ $CACHE_BUILD_OBJECTS = true ]; then
-  if test -d ${cache}/elm-stuff; then
-    echo "-----> Restoring Elm cache"
-    cp -r ${cache}/elm-stuff ${build}/elm-stuff
-  fi
+    if test -d ${cache}/elm-stuff; then
+        echo "-----> Restoring Elm cache"
+        cp -r ${cache}/elm-stuff ${build}/elm-stuff
+    fi
 fi
 
 cd ${build}
@@ -79,6 +79,6 @@ echo "-----> Compiling with ${ELM_COMPILE}"
 ${ELM_COMPILE} | indent
 
 if [ $CACHE_BUILD_OBJECTS = true ]; then
-  # Copy package and compile artifacts back to cache
-  cp -r ${build}/elm-stuff ${cache}/
+    # Copy package and compile artifacts back to cache
+    cp -r ${build}/elm-stuff ${cache}/
 fi


### PR DESCRIPTION
I had a problem where an Elm build was working locally, but when I pushed, the version that the buildpack compiled did not work. I dug and googled around and discovered that in some situations, Elm does not properly invalidate its build cache, causing old artifacts to be brought into new builds when they should be recompiled.

My suggestion (and what this PR does) is to keep these artifacts out of production builds until the native system is more robust.